### PR TITLE
docs(#9): binary download instructions + Go 1.24 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Build
         run: go build -o ctx-ignore ./cmd/ctx-ignore/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ Generated:
 
 ## Install
 
+### Pre-built binary (recommended)
+
+Download the latest binary from [GitHub Releases](https://github.com/arniesaha/ctx-ignore/releases/latest):
+
+**macOS (Apple Silicon)**
+```bash
+curl -L https://github.com/arniesaha/ctx-ignore/releases/latest/download/ctx-ignore_Darwin_arm64.tar.gz | tar xz
+sudo mv ctx-ignore /usr/local/bin/
+```
+
+**macOS (Intel)**
+```bash
+curl -L https://github.com/arniesaha/ctx-ignore/releases/latest/download/ctx-ignore_Darwin_amd64.tar.gz | tar xz
+sudo mv ctx-ignore /usr/local/bin/
+```
+
+**Linux (amd64)**
+```bash
+curl -L https://github.com/arniesaha/ctx-ignore/releases/latest/download/ctx-ignore_Linux_amd64.tar.gz | tar xz
+sudo mv ctx-ignore /usr/local/bin/
+```
+
+### Go install
+
 ```bash
 go install github.com/arniesaha/ctx-ignore/cmd/ctx-ignore@latest
 ```


### PR DESCRIPTION
## Summary

Closes #9

## Changes
- Added pre-built binary download instructions to README for macOS (arm64, amd64) and Linux
- Added Go 1.24 to CI test matrix
- Updated build job to use Go 1.24

Non-Go users can now install ctx-ignore without needing a Go toolchain.