### PR TITLE
feat(#6): add missing noise patterns

### DIFF
--- a/internal/scanner/classifier.go
+++ b/internal/scanner/classifier.go
@@ -60,6 +60,7 @@ var lockfileNames = map[string]bool{
 	"composer.lock":     true,
 	"Pipfile.lock":      true,
 	"bun.lockb":         true,
+	"uv.lock":           true,
 }
 
 // noiseDirNames are directory names that are always noise.
@@ -67,18 +68,28 @@ var noiseDirNames = map[string]struct {
 	level    NoiseLevel
 	category NoiseCategory
 }{
-	"node_modules":  {NoiseLevelRed, CategoryDependency},
-	"vendor":        {NoiseLevelRed, CategoryDependency},
-	".venv":         {NoiseLevelRed, CategoryDependency},
-	"venv":          {NoiseLevelRed, CategoryDependency},
-	"dist":          {NoiseLevelRed, CategoryBuildArtifact},
-	"build":         {NoiseLevelRed, CategoryBuildArtifact},
-	"out":           {NoiseLevelRed, CategoryBuildArtifact},
-	"target":        {NoiseLevelRed, CategoryBuildArtifact},
-	"coverage":      {NoiseLevelRed, CategoryTestArtifact},
-	"__snapshots__": {NoiseLevelRed, CategoryTestArtifact},
-	".idea":         {NoiseLevelRed, CategoryIDEOS},
-	".vscode":       {NoiseLevelRed, CategoryIDEOS},
+	"node_modules":    {NoiseLevelRed, CategoryDependency},
+	"vendor":          {NoiseLevelRed, CategoryDependency},
+	".venv":           {NoiseLevelRed, CategoryDependency},
+	"venv":            {NoiseLevelRed, CategoryDependency},
+	".terraform":      {NoiseLevelRed, CategoryDependency},
+	"dist":            {NoiseLevelRed, CategoryBuildArtifact},
+	"build":           {NoiseLevelRed, CategoryBuildArtifact},
+	"out":             {NoiseLevelRed, CategoryBuildArtifact},
+	"target":          {NoiseLevelRed, CategoryBuildArtifact},
+	".next":           {NoiseLevelRed, CategoryBuildArtifact},
+	".nuxt":           {NoiseLevelRed, CategoryBuildArtifact},
+	"__pycache__":     {NoiseLevelRed, CategoryBuildArtifact},
+	"storybook-static": {NoiseLevelRed, CategoryBuildArtifact},
+	".turbo":          {NoiseLevelRed, CategoryBuildArtifact},
+	".cache":          {NoiseLevelRed, CategoryBuildArtifact},
+	".parcel-cache":   {NoiseLevelRed, CategoryBuildArtifact},
+	"coverage":        {NoiseLevelRed, CategoryTestArtifact},
+	"__snapshots__":   {NoiseLevelRed, CategoryTestArtifact},
+	".pytest_cache":   {NoiseLevelRed, CategoryTestArtifact},
+	".idea":           {NoiseLevelRed, CategoryIDEOS},
+	".vscode":         {NoiseLevelRed, CategoryIDEOS},
+	".mypy_cache":     {NoiseLevelRed, CategoryIDEOS},
 }
 
 // noiseFileExts maps extensions to noise info.
@@ -92,6 +103,8 @@ var noiseFileExts = map[string]struct {
 	".swp":     {NoiseLevelRed, CategoryIDEOS},
 	".log":     {NoiseLevelRed, CategoryIDEOS},
 	".pb.go":   {NoiseLevelRed, CategoryGenerated},
+	".pb.py":   {NoiseLevelRed, CategoryGenerated},
+	".pb.ts":   {NoiseLevelRed, CategoryGenerated},
 }
 
 // noiseFileNames maps exact filenames to noise info.
@@ -99,7 +112,8 @@ var noiseFileNames = map[string]struct {
 	level    NoiseLevel
 	category NoiseCategory
 }{
-	".DS_Store": {NoiseLevelRed, CategoryIDEOS},
+	".DS_Store":  {NoiseLevelRed, CategoryIDEOS},
+	"Thumbs.db":  {NoiseLevelRed, CategoryIDEOS},
 }
 
 // testFilePatterns are suffix patterns that indicate test files.

--- a/internal/scanner/classifier_test.go
+++ b/internal/scanner/classifier_test.go
@@ -210,6 +210,61 @@ func TestClassifyBinaryContent(t *testing.T) {
 	}
 }
 
+func TestClassifyNewNoisePatterns(t *testing.T) {
+	c := NewClassifier()
+
+	// Directories that should be NoiseLevelRed
+	redDirs := []struct {
+		name     string
+		category NoiseCategory
+	}{
+		{".terraform", CategoryDependency},
+		{".next", CategoryBuildArtifact},
+		{"__pycache__", CategoryBuildArtifact},
+		{".pytest_cache", CategoryTestArtifact},
+		{".turbo", CategoryBuildArtifact},
+	}
+	for _, tc := range redDirs {
+		cl := c.ClassifyPath(tc.name, true)
+		if cl.Level != NoiseLevelRed {
+			t.Errorf("dir %s: expected NoiseLevelRed, got %d", tc.name, cl.Level)
+		}
+		if cl.Category != tc.category {
+			t.Errorf("dir %s: expected category %q, got %q", tc.name, tc.category, cl.Category)
+		}
+	}
+
+	// uv.lock should be a lockfile
+	cl := c.ClassifyPath("uv.lock", false)
+	if cl.Level != NoiseLevelRed {
+		t.Errorf("uv.lock: expected NoiseLevelRed, got %d", cl.Level)
+	}
+	if cl.Category != CategoryLockfile {
+		t.Errorf("uv.lock: expected CategoryLockfile, got %q", cl.Category)
+	}
+
+	// Thumbs.db should be IDE/OS noise
+	cl = c.ClassifyPath("Thumbs.db", false)
+	if cl.Level != NoiseLevelRed {
+		t.Errorf("Thumbs.db: expected NoiseLevelRed, got %d", cl.Level)
+	}
+	if cl.Category != CategoryIDEOS {
+		t.Errorf("Thumbs.db: expected CategoryIDEOS, got %q", cl.Category)
+	}
+
+	// .pb.py and .pb.ts extensions should be generated
+	pbFiles := []string{"api.pb.py", "schema.pb.ts"}
+	for _, name := range pbFiles {
+		cl := c.ClassifyPath(name, false)
+		if cl.Level != NoiseLevelRed {
+			t.Errorf("%s: expected NoiseLevelRed, got %d", name, cl.Level)
+		}
+		if cl.Category != CategoryGenerated {
+			t.Errorf("%s: expected CategoryGenerated, got %q", name, cl.Category)
+		}
+	}
+}
+
 func TestClassifyTestArtifacts(t *testing.T) {
 	c := NewClassifier()
 	cases := []struct {


### PR DESCRIPTION
## Summary

Closes #6

## Added patterns

**Directories:** .terraform, .next, .nuxt, __pycache__, .pytest_cache, .mypy_cache, storybook-static, .turbo, .cache, .parcel-cache

**Lockfiles:** uv.lock

**Files:** Thumbs.db

**Extensions:** .pb.py, .pb.ts

## Testing
- All new patterns covered by tests
- go test ./... passes