### PR TITLE
feat(#3): add GitHub Copilot support (.copilotignore)

### DIFF
--- a/cmd/ctx-ignore/main.go
+++ b/cmd/ctx-ignore/main.go
@@ -36,6 +36,7 @@ func scanCmd() *cobra.Command {
 	var dryRun bool
 	var noClaude bool
 	var noCursor bool
+	var noCopilot bool
 	var patchGitIgnore bool
 
 	cmd := &cobra.Command{
@@ -137,6 +138,7 @@ and generate .contextignore, .claudeignore, and .cursorignore files.`,
 			opts := generator.DefaultOptions()
 			opts.WriteClaudeIgnore = !noClaude
 			opts.WriteCursorIgnore = !noCursor
+			opts.WriteCopilotIgnore = !noCopilot
 			opts.PatchGitIgnore = patchGitIgnore
 			opts.DryRun = dryRun
 			opts.OutputDir = abs
@@ -154,6 +156,7 @@ and generate .contextignore, .claudeignore, and .cursorignore files.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print report only, don't write files")
 	cmd.Flags().BoolVar(&noClaude, "no-claude", false, "Skip .claudeignore generation")
 	cmd.Flags().BoolVar(&noCursor, "no-cursor", false, "Skip .cursorignore generation")
+	cmd.Flags().BoolVar(&noCopilot, "no-copilot", false, "Skip .copilotignore generation")
 	cmd.Flags().BoolVar(&patchGitIgnore, "patch-gitignore", false, "Also patch .gitignore")
 
 	return cmd

--- a/internal/generator/writer.go
+++ b/internal/generator/writer.go
@@ -17,6 +17,7 @@ type Options struct {
 	WriteContextIgnore bool
 	WriteClaudeIgnore  bool
 	WriteCursorIgnore  bool
+	WriteCopilotIgnore bool
 	PatchGitIgnore     bool
 	DryRun             bool
 	OutputDir          string
@@ -28,6 +29,7 @@ func DefaultOptions() Options {
 		WriteContextIgnore: true,
 		WriteClaudeIgnore:  true,
 		WriteCursorIgnore:  true,
+		WriteCopilotIgnore: true,
 		PatchGitIgnore:     false,
 		DryRun:             false,
 	}
@@ -74,6 +76,17 @@ func Generate(result *scanner.ScanResult, opts Options) ([]string, error) {
 			}
 		}
 		generated = append(generated, ".cursorignore")
+	}
+
+	if opts.WriteCopilotIgnore {
+		content := buildDerivedIgnore(patterns)
+		if !opts.DryRun {
+			path := filepath.Join(dir, ".copilotignore")
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				return generated, fmt.Errorf("writing .copilotignore: %w", err)
+			}
+		}
+		generated = append(generated, ".copilotignore")
 	}
 
 	if opts.PatchGitIgnore {

--- a/internal/generator/writer_test.go
+++ b/internal/generator/writer_test.go
@@ -93,12 +93,12 @@ func TestGenerateDryRunWritesNoFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(generated) != 3 {
-		t.Errorf("expected 3 generated names, got %d", len(generated))
+	if len(generated) != 4 {
+		t.Errorf("expected 4 generated names, got %d", len(generated))
 	}
 
 	// Verify no files were actually created
-	for _, name := range []string{".contextignore", ".claudeignore", ".cursorignore"} {
+	for _, name := range []string{".contextignore", ".claudeignore", ".cursorignore", ".copilotignore"} {
 		path := filepath.Join(dir, name)
 		if _, err := os.Stat(path); err == nil {
 			t.Errorf("dry run should not create %s", name)
@@ -119,11 +119,11 @@ func TestGenerateCreatesAllFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(generated) != 3 {
-		t.Fatalf("expected 3 generated, got %d: %v", len(generated), generated)
+	if len(generated) != 4 {
+		t.Fatalf("expected 4 generated, got %d: %v", len(generated), generated)
 	}
 
-	for _, name := range []string{".contextignore", ".claudeignore", ".cursorignore"} {
+	for _, name := range []string{".contextignore", ".claudeignore", ".cursorignore", ".copilotignore"} {
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {


### PR DESCRIPTION
## Summary

Closes #3

Adds \`.copilotignore\` generation alongside the existing \`.claudeignore\` and \`.cursorignore\` files.

## Changes
- Added \`WriteCopilotIgnore bool\` to \`generator.Options\`
- \`DefaultOptions()\` enables it by default
- \`Generate()\` writes \`.copilotignore\` using \`buildDerivedIgnore()\`
- Added \`--no-copilot\` flag to skip generation
- Updated tests to expect 4 generated files

## Testing
- \`go test ./...\` passes